### PR TITLE
[FEAT]: 이메일 토픽 파티션 수 8개로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,7 @@ jobs:
             BATCH_SIZE=${{ secrets.BATCH_SIZE }}
             DEFAULT_BATCH_FETCH_SIZE=${{ secrets.DEFAULT_BATCH_FETCH_SIZE }}
             KAFKA_EMAIL_REQUEST=${{ secrets.KAFKA_EMAIL_REQUEST }}
+            KAFKA_PARTITIONS=${{ secrets.KAFKA_PARTITIONS }}
             EMAIL_MAX_ATTEMPTS=${{ secrets.EMAIL_MAX_ATTEMPTS }}
             INITIAL_INTERVAL_MS=${{ secrets.INITIAL_INTERVAL_MS }}
             MAX_INTERVAL_MS=${{ secrets.MAX_INTERVAL_MS }}

--- a/src/main/java/com/ureca/only4_be/kafka/config/KafkaTopicConfig.java
+++ b/src/main/java/com/ureca/only4_be/kafka/config/KafkaTopicConfig.java
@@ -17,7 +17,7 @@ public class KafkaTopicConfig {
     @Bean
     public NewTopic emailRequestTopic() {
         return TopicBuilder.name(properties.emailRequest())
-                .partitions(1)
+                .partitions(properties.partitions())
                 .replicas(1)
                 .build();
     }

--- a/src/main/java/com/ureca/only4_be/kafka/properties/KafkaTopicsProperties.java
+++ b/src/main/java/com/ureca/only4_be/kafka/properties/KafkaTopicsProperties.java
@@ -5,5 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "app.kafka.topics")
 public record KafkaTopicsProperties(
         String groupId,
-        String emailRequest
+        String emailRequest,
+        Integer partitions
 ) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,7 @@ app:
     topics:
       group-id: ${KAFKA_GROUP_ID}
       email-request: ${KAFKA_EMAIL_REQUEST}
+      partitions: ${KAFKA_PARTITIONS:8}
 
     retry: # 재시도 관련 설정
       email-max-attempts: ${EMAIL_MAX_ATTEMPTS:2}


### PR DESCRIPTION
## 📝 작업 내용
> 이메일 토픽 파티션 수 환경 변수로 빼고 디폴트 값 8로 지정

- [x] application.yml
- [x] deploy.yml
- [x] KafkaTopicConfig.yml
- [x] KafkaTopicProperties

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> #106 


## 💬 리뷰 요구사항
