### PR TITLE
[FEAT]: 배포 환경에서 컨트롤러 호출 기능 추가 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,6 +194,12 @@ jobs:
             MAX_INTERVAL_MS=${{ secrets.MAX_INTERVAL_MS }}
             SETTLEMENT_MIN=${{ secrets.SETTLEMENT_MIN }}
             SETTLEMENT_MAX=${{ secrets.SETTLEMENT_MAX }}
+            ECS_CLUSTER=${{ secrets.ECS_CLUSTER }}
+            ECS_SUBNET_IDS=${{ secrets.ECS_SUBNET_IDS }}
+            ECS_SECURITY_GROUP_IDS=${{ secrets.ECS_SECURITY_GROUP_IDS }}
+            AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }}
+            SCHEDULER_EXECUTION_ROLE_ARN=${{ secrets.SCHEDULER_EXECUTION_ROLE_ARN }}
+            CORS_ALLOWED_ORIGINS=${{ secrets.CORS_ALLOWED_ORIGINS }}
             EOF
             
             aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ steps.login-ecr.outputs.registry }}

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,11 @@ dependencies {
 	// 8. Swagger (Spring Boot 3 호환 버전으로 업그레이드 권장: (Spring Boot 3.4 완벽 호환)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 
-	// 9. Test
+	// 9. AWS SDK
+	implementation platform('software.amazon.awssdk:bom:2.21.1')
+	implementation 'software.amazon.awssdk:ecs'
+
+	// 10. Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 	// 9. AWS SDK
 	implementation platform('software.amazon.awssdk:bom:2.21.1')
 	implementation 'software.amazon.awssdk:ecs'
+	implementation 'software.amazon.awssdk:scheduler'
 
 	// 10. Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/ureca/only4_be/api/service/NotificationService.java
+++ b/src/main/java/com/ureca/only4_be/api/service/NotificationService.java
@@ -17,6 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.ureca.only4_be.global.service.EcsTaskService;
+import org.springframework.core.env.Environment;
+import software.amazon.awssdk.services.ecs.model.KeyValuePair;
+import org.springframework.beans.factory.annotation.Value;
+import java.util.Arrays;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -24,6 +30,12 @@ public class NotificationService {
 
     private final BillNotificationRepository billNotificationRepository;
     private final JobLauncher jobLauncher;
+    private final EcsTaskService ecsTaskService;
+    private final Environment env;
+
+    // 배포된 notification-task
+    @Value("${cloud.aws.ecs.task-definitions.notification:}")
+    private String notificationTaskDefinition;
 
 
     @Qualifier("notificationJob")
@@ -35,6 +47,24 @@ public class NotificationService {
     }
     public BatchJobResponse runManualBatch(String dateStr){
         String targetDate = (dateStr !=null) ? dateStr : LocalDate.now().toString();
+
+        // [Prod 환경 분기 처리]
+        if (Arrays.asList(env.getActiveProfiles()).contains("prod")) {
+            log.info(">>>> [Prod Env] 알림 발송 배치 ECS Task 요청");
+            List<KeyValuePair> envVars = List.of(
+                    KeyValuePair.builder().name("BILLING_DATE").value(targetDate).build(),
+                    KeyValuePair.builder().name("run.id").value(String.valueOf(System.currentTimeMillis())).build()
+            );
+            // task-notification.json과 값 일치
+            ecsTaskService.runTask(notificationTaskDefinition, "notification-container", envVars);
+
+            return BatchJobResponse.builder()
+                    .jobId(0L)
+                    .status("ECS_STARTED")
+                    .exitCode("UNKNOWN")
+                    .startTime(java.time.LocalDateTime.now())
+                    .build();
+        }
 
         try{
             log.info(">>> [Service] 수동 배치 실행 시작. 기준일: {}", targetDate);

--- a/src/main/java/com/ureca/only4_be/global/config/WebMvcConfig.java
+++ b/src/main/java/com/ureca/only4_be/global/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package com.ureca.only4_be.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -10,14 +11,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final long MAX_AGE_SECS = 3600;
 
-//    @Value("${app.cors.allowed-origins}")
-//    private String[] allowedOrigins;
+    @Value("${app.cors.allowed-origins:*}")
+    private String[] allowedOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-//                .allowedOrigins(allowedOrigins)
-                .allowedOriginPatterns("*")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/com/ureca/only4_be/global/service/EcsTaskService.java
+++ b/src/main/java/com/ureca/only4_be/global/service/EcsTaskService.java
@@ -1,0 +1,75 @@
+package com.ureca.only4_be.global.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.*;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EcsTaskService {
+
+    @Value("${cloud.aws.ecs.cluster-name:}")
+    private String clusterName;
+
+    @Value("${cloud.aws.ecs.region:ap-northeast-2}")
+    private String region;
+
+    @Value("${cloud.aws.ecs.subnet-ids:}")
+    private String subnetIds;
+
+    @Value("${cloud.aws.ecs.security-group-ids:}")
+    private String securityGroupIds;
+
+    public String runTask(String taskDefinitionName, String containerName, List<KeyValuePair> envVars) {
+        if (clusterName == null || clusterName.isEmpty()) {
+            log.warn("ECS cluster name is not configured. Skipping ECS task execution.");
+            return "ECS_NOT_CONFIGURED";
+        }
+
+        try (EcsClient ecsClient = EcsClient.builder().region(Region.of(region)).build()) {
+            AwsVpcConfiguration vpcConfig = AwsVpcConfiguration.builder()
+                    .subnets(subnetIds.split(","))
+                    .securityGroups(securityGroupIds.split(","))
+                    .assignPublicIp(AssignPublicIp.ENABLED)
+                    .build();
+
+            NetworkConfiguration networkConfig = NetworkConfiguration.builder()
+                    .awsvpcConfiguration(vpcConfig)
+                    .build();
+
+            ContainerOverride containerOverride = ContainerOverride.builder()
+                    .name(containerName)
+                    .environment(envVars)
+                    .build();
+
+            TaskOverride taskOverride = TaskOverride.builder()
+                    .containerOverrides(containerOverride)
+                    .build();
+
+            RunTaskRequest runTaskRequest = RunTaskRequest.builder()
+                    .cluster(clusterName)
+                    .taskDefinition(taskDefinitionName)
+                    .launchType(LaunchType.FARGATE)
+                    .networkConfiguration(networkConfig)
+                    .overrides(taskOverride)
+                    .count(1)
+                    .build();
+
+            RunTaskResponse response = ecsClient.runTask(runTaskRequest);
+            String taskArn = response.tasks().getFirst().taskArn();
+            log.info("ECS Task Started: {}", taskArn);
+            return taskArn;
+
+        } catch (Exception e) {
+            log.error("Failed to run ECS task", e);
+            throw new RuntimeException("ECS Task 실행 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/ureca/only4_be/global/service/EventBridgeSchedulerService.java
+++ b/src/main/java/com/ureca/only4_be/global/service/EventBridgeSchedulerService.java
@@ -1,0 +1,133 @@
+package com.ureca.only4_be.global.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.scheduler.SchedulerClient;
+import software.amazon.awssdk.services.scheduler.model.*;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventBridgeSchedulerService {
+
+    @Value("${cloud.aws.ecs.cluster-name:}")
+    private String clusterName;
+
+    @Value("${cloud.aws.ecs.region:ap-northeast-2}")
+    private String region;
+
+    @Value("${cloud.aws.ecs.subnet-ids:}")
+    private String subnetIds;
+
+    @Value("${cloud.aws.ecs.security-group-ids:}")
+    private String securityGroupIds;
+
+    @Value("${cloud.aws.ecs.task-definitions.notification:only4-notification-task}")
+    private String notificationTaskDefinitionArn;
+
+    // Scheduler가 ECS Task를 실행할 때 사용할 Role ARN (EventBridge Scheduler용 Role)
+    // 이 Role은 ecs:RunTask 권한과 iam:PassRole 권한을 가지고 있어야 함
+    @Value("${cloud.aws.scheduler.execution-role-arn:}")
+    private String schedulerExecutionRoleArn;
+
+    private static final String SCHEDULE_GROUP_NAME = "default"; 
+
+    /**
+     * EventBridge Scheduler에 1회성 스케줄 생성
+     */
+    public void createSchedule(Long reservationId, LocalDateTime executeAt) {
+        if (schedulerExecutionRoleArn == null || schedulerExecutionRoleArn.isEmpty()) {
+            log.warn("Scheduler Execution Role ARN is missing. Skipping schedule creation.");
+            return;
+        }
+
+        try (SchedulerClient client = SchedulerClient.builder().region(Region.of(region)).build()) {
+
+            String scheduleName = "reservation-" + reservationId;
+            // EventBridge Scheduler는 UTC 기준 ISO8601 형식을 권장하지만, at()으로 로컬 타임존 지정 가능
+            // 예: "2026-01-25T10:00:00"
+            String atExpression = "at(" + executeAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + ")";
+
+            // ECS Parameters 설정
+            EcsParameters ecsParams = EcsParameters.builder()
+                    .taskDefinitionArn(notificationTaskDefinitionArn)
+                    .launchType(LaunchType.FARGATE)
+                    .networkConfiguration(NetworkConfiguration.builder()
+                            .awsvpcConfiguration(AwsVpcConfiguration.builder()
+                                    .subnets(subnetIds.split(","))
+                                    .securityGroups(securityGroupIds.split(","))
+                                    .assignPublicIp(AssignPublicIp.ENABLED)
+                                    .build())
+                            .build())
+                    .build();
+
+            // Target 설정 (ECS RunTask)
+            Target target = Target.builder()
+                    .arn("arn:aws:ecs:" + region + ":" + getAccountId() + ":cluster/" + clusterName) // Cluster ARN
+                    .roleArn(schedulerExecutionRoleArn) // Scheduler가 사용할 Role
+                    .ecsParameters(ecsParams)
+                    .input("{\"containerOverrides\": [{\"name\": \"notification-container\", \"environment\": [{\"name\": \"run.id\", \"value\": \"" + System.currentTimeMillis() + "\"}]}]}")
+                    .build();
+
+            CreateScheduleRequest request = CreateScheduleRequest.builder()
+                    .name(scheduleName)
+                    .groupName(SCHEDULE_GROUP_NAME)
+                    .scheduleExpression(atExpression)
+                    .scheduleExpressionTimezone("Asia/Seoul") // 한국 시간 기준
+                    .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                    .target(target)
+                    .description("Only4 Reservation Notification for ID: " + reservationId) // 실행 후 스케줄 자동 삭제
+                    .actionAfterCompletion(ActionAfterCompletion.DELETE) 
+                    .build();
+
+            client.createSchedule(request);
+            log.info("Created EventBridge Schedule: {} at {}", scheduleName, executeAt);
+
+        } catch (Exception e) {
+            log.error("Failed to create EventBridge schedule", e);
+            throw new RuntimeException("스케줄 생성 실패", e);
+        }
+    }
+
+    /**
+     * 스케줄 삭제 (예약 취소 시)
+     */
+    public void deleteSchedule(Long reservationId) {
+        try (SchedulerClient client = SchedulerClient.builder().region(Region.of(region)).build()) {
+            String scheduleName = "reservation-" + reservationId;
+            
+            DeleteScheduleRequest request = DeleteScheduleRequest.builder()
+                    .name(scheduleName)
+                    .groupName(SCHEDULE_GROUP_NAME)
+                    .build();
+
+            client.deleteSchedule(request);
+            log.info("Deleted EventBridge Schedule: {}", scheduleName);
+        } catch (ResourceNotFoundException e) {
+            log.warn("Schedule not found, skipping delete: reservation-{}", reservationId);
+        } catch (Exception e) {
+            log.error("Failed to delete EventBridge schedule", e);
+            throw new RuntimeException("스케줄 삭제 실패", e);
+        }
+    }
+    
+    // 편의상 Account ID를 가져오거나 설정으로 받아야 함. 
+    // 여기서는 ARN 파싱 대신 간단히 환경변수 주입을 권장하지만, 임시로 로직 내에서 처리하려면 STS 호출이 필요.
+    // 일단 .env나 yml에서 주입받는 구조로 가정하고 Getter 추가.
+    @Value("${cloud.aws.account-id:}")
+    private String accountId;
+    
+    private String getAccountId() {
+        if (accountId == null || accountId.isEmpty()) {
+            throw new IllegalStateException("AWS Account ID is not configured.");
+        }
+        return accountId;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,3 +31,6 @@ cloud:
       task-definitions:
         settlement: only4-settlement-task
         notification: only4-notification-task
+    scheduler:
+      execution-role-arn: ${SCHEDULER_EXECUTION_ROLE_ARN}
+    account-id: ${AWS_ACCOUNT_ID}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,14 @@ spring:
   kafka:
     # 실제 운영 카프카 주소
     bootstrap-servers: ${PROD_KAFKA_URL}:9092
+
+cloud:
+  aws:
+    ecs:
+      cluster-name: ${ECS_CLUSTER}
+      region: ${AWS_REGION:ap-northeast-2}
+      subnet-ids: ${ECS_SUBNET_IDS}
+      security-group-ids: ${ECS_SECURITY_GROUP_IDS}
+      task-definitions:
+        settlement: only4-settlement-task
+        notification: only4-notification-task

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,8 @@ spring:
 # [커스텀 앱 설정]
 # ==========================================
 app:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:*}
   kafka:
     topics:
       group-id: ${KAFKA_GROUP_ID}

--- a/task-notification.json
+++ b/task-notification.json
@@ -15,7 +15,8 @@
         "java",
         "-jar",
         "app.jar",
-        "--spring.batch.job.name=notificationJob"
+        "--spring.batch.job.name=notificationJob",
+        "--spring.main.web-application-type=none"
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/task-settlement.json
+++ b/task-settlement.json
@@ -15,7 +15,8 @@
         "java",
         "-jar",
         "app.jar",
-        "--spring.batch.job.name=settlementJob"
+        "--spring.batch.job.name=settlementJob",
+        "--spring.main.web-application-type=none"
       ],
       "logConfiguration": {
         "logDriver": "awslogs",


### PR DESCRIPTION
## 📝 작업 내용
> 배포 환경에서는 서버가 분리되어 있기 때문에 직접 함수를 호출하는 것이 아니라, ECS Fargate의 Task를 직접 실행시키는 로직을 작성해야함

- [x] deploy.yml
- [x] build.gradle
- [x] WebMvcConfig - 프론트, 백엔드 배포 주소 포함
- [x] SettlementService - 배포 환경에서는 AWS SDK 이용해 Task 실행하도록 로직 추가
- [x] NotificationService - 이하동문
- [x] ReservationNotificationService - AWS Event Bridge Scheduler에 스케줄 생성하도록
- [x] ECSTaskService - AWS Task 실행
- [x]  EventBridgeSchedulerService - AWS Event Scheduler 등록

### 📷 스크린샷


## ☑️ 체크 리스트
> 체크  리스트를 확인해주세요
- [x] 테스트는 잘 통과했나요?
- [x] 충돌을 해결했나요?
- [x] 이슈는 등록했나요?
- [x] 라벨은 등록했나요?


## #️⃣ 연관된 이슈
> #117 


## 💬 리뷰 요구사항
